### PR TITLE
Wrong basisjs tag on github

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "licenses": "MIT",
   "dependencies": {},
   "devDependencies": {
-    "basisjs": "basisjs/basisjs#1.5",
+    "basisjs": "basisjs/basisjs#v1.5.1",
     "basisjs-tools": "basisjs/basisjs-tools"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "licenses": "MIT",
   "dependencies": {},
   "devDependencies": {
-    "basisjs": "basisjs/basisjs#v1.5.1",
-    "basisjs-tools": "basisjs/basisjs-tools"
+    "basisjs": "^1.5.1",
+    "basisjs-tools": "^1.6.1"
   },
   "scripts": {
     "build": "basis build"


### PR DESCRIPTION
I cloned a repo and tried to install dependences, but 

```
$ cat npm-debug.log
0 info it worked if it ends with ok
1 verbose cli [ 'node', '/usr/local/bin/npm', 'install' ]
2 info using npm@2.14.4
3 info using node@v0.12.7
4 verbose node symlink /usr/local/bin/node
5 verbose readDependencies loading dependencies from /Users/user/Documents/component-inspector/package.json
...
66 silly cache afterAdd basisjs-tools@1.6.1
67 verbose afterAdd /Users/user/.npm/basisjs-tools/1.6.1/package/package.json not in flight; writing
68 verbose afterAdd /Users/user/.npm/basisjs-tools/1.6.1/package/package.json written
69 verbose updateRemote git fetch -a origin (https://github.com/basisjs/basisjs.git)
70 verbose setPermissions basisjs/basisjs#1.5 set permissions on /Users/user/.npm/_git-remotes/https-github-com-basisjs-basisjs-git-7247a44d
71 verbose resolveHead basisjs/basisjs#1.5 original treeish: 1.5
72 info git [ 'rev-list', '-n1', '1.5' ]
73 error git rev-list -n1 1.5: fatal: ambiguous argument '1.5': unknown revision or path not in the working tree.
73 error git rev-list -n1 1.5: Use '--' to separate paths from revisions, like this:
73 error git rev-list -n1 1.5: 'git <command> [<revision>...] -- [<file>...]'
74 silly trySSH attempting to clone git@github.com:basisjs/basisjs.git#1.5
75 silly tryClone cloning basisjs/basisjs#1.5 via git@github.com:basisjs/basisjs.git#1.5
76 verbose tryClone git-github-com-basisjs-basisjs-git-90dd9f88 not in flight; caching
77 info git [ 'config', '--get', 'remote.origin.url' ]
78 silly validateExistingRemote basisjs/basisjs#1.5 remote.origin.url: git@github.com:basisjs/basisjs.git
79 verbose validateExistingRemote basisjs/basisjs#1.5 is updating existing cached remote /Users/user/.npm/_git-remotes/git-github-com-basisjs-basisjs-git-90dd9f88
80 info git [ 'fetch', '-a', 'origin' ]
81 verbose updateRemote git fetch -a origin (git@github.com:basisjs/basisjs.git)
82 verbose setPermissions basisjs/basisjs#1.5 set permissions on /Users/user/.npm/_git-remotes/git-github-com-basisjs-basisjs-git-90dd9f88
83 verbose resolveHead basisjs/basisjs#1.5 original treeish: 1.5
84 info git [ 'rev-list', '-n1', '1.5' ]
85 error git rev-list -n1 1.5: fatal: ambiguous argument '1.5': unknown revision or path not in the working tree.
85 error git rev-list -n1 1.5: Use '--' to separate paths from revisions, like this:
85 error git rev-list -n1 1.5: 'git <command> [<revision>...] -- [<file>...]'
86 verbose stack Error: Command failed: git rev-list -n1 1.5
86 verbose stack fatal: ambiguous argument '1.5': unknown revision or path not in the working tree.
86 verbose stack Use '--' to separate paths from revisions, like this:
86 verbose stack 'git <command> [<revision>...] -- [<file>...]'
86 verbose stack
86 verbose stack     at ChildProcess.exithandler (child_process.js:751:12)
86 verbose stack     at ChildProcess.emit (events.js:110:17)
86 verbose stack     at maybeClose (child_process.js:1015:16)
86 verbose stack     at Socket.<anonymous> (child_process.js:1183:11)
86 verbose stack     at Socket.emit (events.js:107:17)
86 verbose stack     at Pipe.close (net.js:485:12)
87 verbose cwd /Users/user/Documents/component-inspector
88 error Darwin 15.0.0
89 error argv "node" "/usr/local/bin/npm" "install"
90 error node v0.12.7
91 error npm  v2.14.4
92 error code 128
93 error Command failed: git rev-list -n1 1.5
93 error fatal: ambiguous argument '1.5': unknown revision or path not in the working tree.
93 error Use '--' to separate paths from revisions, like this:
93 error 'git <command> [<revision>...] -- [<file>...]'
94 error If you need help, you may report this error at:
94 error     <https://github.com/npm/npm/issues>
95 verbose exit [ 1, true ]
```